### PR TITLE
always show help link on mobile screens, move help icon above other c…

### DIFF
--- a/js/css/custom.css
+++ b/js/css/custom.css
@@ -328,6 +328,12 @@ th[role='columnheader'] .help, .help-target .help {
 	visibility: hidden;
 }
 
+@media (max-width: 1024px) { /* Ensures help icon is always visible on most touchscreen devices */
+    th[role='columnheader'] .help, .help-target .help {
+        visibility: visible;
+    }
+}
+
 .markdown img {
 	width: 100%
 }
@@ -338,6 +344,8 @@ th[role='columnheader'] .help, .help-target .help {
 
 .glyphicon.help {
     margin: 3px;
+    cursor: pointer;
+    z-index: 10;
 }
 .sources-fields label {
     width: 7.5em;


### PR DESCRIPTION
This PR ensures that _most_ touch screens will always display help icons since hovering is not possible. It also updates styles and improves accessibility to help icons by displaying them above other content in stacking context.

Touch screens are defined here simply as any window with a maximum width of 1024px. This is imperfect, but a reasonable and simple precedent for how to determine whether or not a device could be considered "mobile" for display purposes.