### PR TITLE
closes #149

### DIFF
--- a/js/css/custom.css
+++ b/js/css/custom.css
@@ -328,6 +328,12 @@ th[role='columnheader'] .help, .help-target .help {
 	visibility: hidden;
 }
 
+@media (max-width: 1024px) { /* Ensures help icon is always visible on most touchscreen devices */
+    th[role='columnheader'] .help, .help-target .help {
+        visibility: visible;
+    }
+}
+
 .markdown img {
 	width: 100%
 }
@@ -338,6 +344,8 @@ th[role='columnheader'] .help, .help-target .help {
 
 .glyphicon.help {
     margin: 3px;
+    cursor: pointer;
+    z-index: 10;
 }
 .sources-fields label {
     width: 7.5em;


### PR DESCRIPTION
This PR ensures that most touch screens will display help icons by default since hovering is not possible (this resolves the need to double tap to input queries). It also updates styles and improves accessibility to help icons by displaying them above other content in stacking context.

Touch screens are defined here simply as any window with a maximum width of 1024px. This is imperfect, though a simple, proposed precedent for how to determine whether or not a device could be considered "mobile" for display purposes.