### PR TITLE
fix mislocation of wsgi in django settings

### DIFF
--- a/django/brca/settings.py
+++ b/django/brca/settings.py
@@ -88,7 +88,7 @@ TEMPLATES = [
      },
 ]
 
-WSGI_APPLICATION = 'brca.wsgi.application'
+WSGI_APPLICATION = 'wsgi.application'
 
 # Password validation
 # https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators


### PR DESCRIPTION
the wsgi config is currently located in brca-website/django/wsgi.py and not django/brca/wsgi.py. this resolves an issue connecting to the server on local.