### PR TITLE
closes #161

### DIFF
--- a/js/DataTable.js
+++ b/js/DataTable.js
@@ -264,7 +264,7 @@ var DataTable = React.createClass({
                     </Col>
                 </Row>
                 <Row>
-                    <Col className="table-responsive" sm={10} smOffset={1}>
+                    <Col id="data-table-container" className="table-responsive" sm={10} smOffset={1}>
                         <FastTable
                             className={cx(className, "table table-hover table-bordered table-condensed")}
                             dataArray={data}

--- a/js/css/custom.css
+++ b/js/css/custom.css
@@ -270,6 +270,25 @@ div#main {
     word-wrap: break-word;
     float: left;
 }
+
+/* id helper to access the variant data table for better responsive layouts */
+#data-table-container {
+    overflow-x: visible;
+}
+
+@media only screen and (min-width: 768px) {
+    #data-table-container table {
+        table-layout: fixed;
+        min-width: 612px;
+    }
+
+    #data-table-container table td,
+    #data-table-container table th {
+        word-wrap: break-word;
+        white-space: normal;
+    }
+}
+
 /**************************************************************/
 /**********     Other                     *********************/
 /**************************************************************/


### PR DESCRIPTION
Desktop: Maintains table size while scrolling through pages, wraps table cell data when necessary on desktop, fixes hidden right border which leads to confusion.

Mobile: Maintains existing styles and scrolling (single lines of content, prevents wrapping which is extremely difficult to read on mobile)

