### PR TITLE
fix reference to wsgi -- double check with team before deployment

### DIFF
--- a/django/brca/settings.py
+++ b/django/brca/settings.py
@@ -88,7 +88,7 @@ TEMPLATES = [
      },
 ]
 
-WSGI_APPLICATION = 'brca.wsgi.application'
+WSGI_APPLICATION = 'wsgi.application'
 
 # Password validation
 # https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators


### PR DESCRIPTION
wsgi.py currently lives in brca-website/django/, not brca-website/django/brca/, so I've changed the reference in settings.py to prevent server errors locally and on dev servers. I don't have access to beta or production servers to confirm that this change is safe there as well, please confirm before merging this PR.